### PR TITLE
Arreglar dependencias OpenAPI, algunos arreglos menores

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,13 +26,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-web-services")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.2") //
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.14")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
+    implementation("org.springdoc:springdoc-openapi-starter-common:2.2.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("org.springframework.boot:spring-boot-devtools")
 
     // testing

--- a/src/main/kotlin/org/uqbar/biblioteca/domain/Biblioteca.kt
+++ b/src/main/kotlin/org/uqbar/biblioteca/domain/Biblioteca.kt
@@ -2,7 +2,7 @@ package org.uqbar.biblioteca.domain
 
 class Biblioteca {
 
-    val libros = mutableListOf<Libro>()
+    private val libros = mutableListOf<Libro>()
 
     /**
      * Helper method para agregar un libro
@@ -15,7 +15,7 @@ class Biblioteca {
         libro.validar()
         val index = this.libros.indexOfFirst { libro.id == it.id }
         if (index >= 0) {
-            this.libros.set(index, libro)
+            this.libros[index] = libro
         } else {
             this.libros.add(libro)
         }

--- a/src/main/kotlin/org/uqbar/biblioteca/domain/BusinessException.kt
+++ b/src/main/kotlin/org/uqbar/biblioteca/domain/BusinessException.kt
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)
-class BusinessException(mensaje: String) : RuntimeException(mensaje) {}
+class BusinessException(mensaje: String) : RuntimeException(mensaje)
 
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-class NotFoundException(mensaje: String) : RuntimeException(mensaje) {}
+class NotFoundException(mensaje: String) : RuntimeException(mensaje)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,5 +3,6 @@ server:
     include-message: always
     include-binding-errors: always
     include-exception: false
+  servlet:
     context-path: /api/v1
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,5 +3,6 @@ server:
     include-message: always
     include-binding-errors: always
     include-exception: true
+  servlet:
     context-path: /api/v1
 


### PR DESCRIPTION
* En Spring Boot 3, springdoc-openapi pasa de 1.x.x a 2.x.x, con el estandar OpenAPI 3 en vez de OpenAPI 2.
* Se eliminó una dependencia duplicada para jackson-module-kotlin, y se actualizó jackson-datatype-jsr310 a la versión correcta para la versión usada de Spring Boot.
* Se arreglo la configuración en el archivo `application.yml`, ahora el servidor levanta en `http://localhost:8080/api/v1/` como parecía ser la intención.
* Otros arreglos menores

---

Como extra, [hay una rama aparte basada en esta](https://github.com/uqbar-project/eg-biblioteca-springboot-kotlin/compare/faker?expand=1) que agrega como dependencia [datafaker](github.com/datafaker-net/datafaker), y altera ligeramente la forma de ejecución de los tests. Para mirar, y potencialmente mergear posterior al merge de este PR.